### PR TITLE
Updates to flashback parameter handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 .PHONY: activate-venv build docker-build docker-push test clean-build clean-pyc clean all
 
 include .env
+include tests/.env
 export
 
 VENV?=.venv
@@ -30,6 +31,7 @@ docker-push:
 test: activate-venv
 	pip install -r tests/requirements.txt
 	docker-compose -f tests/docker-compose.yml up -d --wait
+	docker-compose -f tests/docker-compose.yml exec database ./setPassword.sh ${ORACLE_PWD}
 	pytest
 
 clean-build:

--- a/README.md
+++ b/README.md
@@ -279,8 +279,8 @@ options:
                         Remap schema FROM_SCHEMA:TO_SCHEMA
   --remap_tablespace REMAP_TABLESPACE
                         Remap tablespace FROM_TBLSPC:TO_TBLSPC
-  --flashback_utc FLASHBACK_UTC
-                        ISO format UTC timestamp
+  --flashback_time FLASHBACK_TIME
+                        ISO format timestamp
   --directive DIRECTIVE
                         Datapump directive NAME:VALUE
 ```
@@ -397,7 +397,7 @@ ENCRYPTION_PASSWORD - args: value: {PASSWORD, DUAL}
 ESTIMATE - args: value: {BLOCKS, STATISTICS}
 ESTIMATE_ONLY - args: value: int
 FLASHBACK_SCN - args: value: int
-FLASHBACK_TIME - args: value: str | datetime # Must be UTC ISO format.
+FLASHBACK_TIME - args: value: str | datetime # Must be an ISO format timestamp.
 INCLUDE_METADATA - args: value: bool
 KEEP_MASTER - args: value: bool
 LOGTIME - args: value: {NONE, STATUS, LOGFILE, ALL}

--- a/src/oracledb_datapump/constants.py
+++ b/src/oracledb_datapump/constants.py
@@ -2,6 +2,7 @@ from typing import Final, Literal, Type, TypeAlias
 
 DEFAULT_DP_DIR: Final[str] = "DATA_PUMP_DIR"
 DATE_STR_FMT: Final[str] = "%Y%m%d%H%M%S%f"
+ISO_TIMESTAMP_MASK: Final[str] = 'YYYY-MM-DD"T"HH24:MI:SS.FF'
 DMP_CREATE_DATE_STR_FMT: Final[str] = "%c"
 SUB_SEQ_VAR: Final[str] = "%U"
 FLYWAY_SCHEMA_HISTORY_ENV: Final[str] = "FLYWAY_SCHEMA_HISTORY"

--- a/src/oracledb_datapump/directives.py
+++ b/src/oracledb_datapump/directives.py
@@ -23,7 +23,7 @@ from oracledb_datapump.database import Schema
 from oracledb_datapump.exceptions import InvalidObjectType
 from oracledb_datapump.files import OracleFile
 from oracledb_datapump.log import get_logger
-from oracledb_datapump.util import try_parse_dt
+from oracledb_datapump.util import parse_dt
 
 logger = get_logger(__name__)
 
@@ -308,11 +308,7 @@ class FlashbackScn(ParameterTypeWithUserArgs[int], name="FLASHBACK_SCN"):
 
 class FlashbackTime(ParameterTypeWithUserArgs[str], name="FLASHBACK_TIME"):
     def __init__(self, value: str | datetime):
-        # arg: UTC datetime
-        dt = try_parse_dt(value)
-
-        if not isinstance(dt, datetime):
-            raise ValueError(f"Invalid UTC datetime: {value}")
+        dt: datetime = parse_dt(value)
         self.value = "to_utc_timestamp_tz('{}')".format(dt.isoformat())
 
     @property

--- a/src/oracledb_datapump/entrypoints/cli.py
+++ b/src/oracledb_datapump/entrypoints/cli.py
@@ -11,7 +11,7 @@ from oracledb_datapump.base import ConnectDict
 from oracledb_datapump.client import DataPump
 from oracledb_datapump.exceptions import BadRequest, UsageError
 from oracledb_datapump.log import DEFAULT_LOG_FMT, get_logger
-from oracledb_datapump.util import try_parse_dt
+from oracledb_datapump.util import parse_dt
 
 if TYPE_CHECKING:
     from oracledb_datapump.request import JobDirective
@@ -207,9 +207,7 @@ def parse_directives(
                 )
 
     if flashback_utc:
-        dt = try_parse_dt(flashback_utc)
-        if isinstance(dt, str):
-            raise ValueError(f"Invalid UTC datetime: {flashback_utc}")
+        dt: datetime = parse_dt(flashback_utc)
         job_directives.append({"name": "FLASHBACK_TIME", "value": dt.isoformat()})
 
     if directives:

--- a/src/oracledb_datapump/entrypoints/cli.py
+++ b/src/oracledb_datapump/entrypoints/cli.py
@@ -72,7 +72,7 @@ def main() -> int:
         help="Remap tablespace FROM_TBLSPC:TO_TBLSPC",
     )
     parser.add_argument(
-        "--flashback_utc", default=None, help="ISO format UTC timestamp"
+        "--flashback_time", default=None, help="ISO format timestamp"
     )
     parser.add_argument(
         "--directive", action="append", default=[], help="Datapump directive NAME:VALUE"
@@ -109,7 +109,7 @@ def main() -> int:
         exclude=args.exclude,
         remap_schema=args.remap_schema,
         remap_tablespace=args.remap_tablespace,
-        flashback_utc=args.flashback_utc,
+        flashback_time=args.flashback_time,
         directives=args.directive,
     )
 
@@ -155,7 +155,7 @@ def parse_directives(
     exclude: list[str] | None = None,
     remap_schema: list[str] | None = None,
     remap_tablespace: list[str] | None = None,
-    flashback_utc: datetime | str | None = None,
+    flashback_time: datetime | str | None = None,
     directives: list[str] | None = None,
 ) -> list["JobDirective"]:
 
@@ -206,8 +206,8 @@ def parse_directives(
                     " FROM_VALUE:TO_VALUE"
                 )
 
-    if flashback_utc:
-        dt: datetime = parse_dt(flashback_utc)
+    if flashback_time:
+        dt: datetime = parse_dt(flashback_time)
         job_directives.append({"name": "FLASHBACK_TIME", "value": dt.isoformat()})
 
     if directives:

--- a/src/oracledb_datapump/sql.py
+++ b/src/oracledb_datapump/sql.py
@@ -85,6 +85,10 @@ SQL_GET_FLYWAY_SCHEMA_VERSION = """
     fetch first 1 rows only
 """
 
+SQL_GET_DB_TIMEZONE = "select dbtimezone from dual"
+
+SQL_TIMESTAMP_TO_SCN = "select timestamp_to_scn(:dt) from dual"
+
 PLSQL_DROP_ORPHAN = """
     -- drop master table for "orphaned job" if it exists
     begin

--- a/src/oracledb_datapump/util.py
+++ b/src/oracledb_datapump/util.py
@@ -64,13 +64,13 @@ def str_or_kv(x: str | tuple[str, str]) -> tuple[str, str | None]:
         return x
 
 
-def try_parse_dt(s: str | datetime) -> datetime | str:
+def parse_dt(s: str | datetime) -> datetime:
     if isinstance(s, datetime):
         return s
     try:
         return datetime.fromisoformat(s)
     except ValueError:
-        return s
+        raise ValueError(f"Invalid ISO datetime string: {s}")
 
 
 def parse_colon_delimited(val):

--- a/src/oracledb_datapump/util.py
+++ b/src/oracledb_datapump/util.py
@@ -100,3 +100,7 @@ class JsonSerializer(json.JSONEncoder):
         if isinstance(o, datetime):
             return o.strftime(constants.DATE_STR_FMT)
         return super().default(o)
+
+
+def is_timezone_aware(dt: datetime) -> bool:
+    return dt.tzinfo is not None and dt.tzinfo.utcoffset(dt) is not None

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -2,6 +2,8 @@ services:
   database:
     image: container-registry.oracle.com/database/enterprise:19.3.0.0
     container_name: datapump_db
+    env_file:
+      - .env
     ports:
       - 1521:1521
       - 8080:8080


### PR DESCRIPTION
- Pass database local timestamps as flashback time parameters. 
- Default to passing an SCN flashback parameter equal to the job_date if no flashback directive is given.